### PR TITLE
Change GET image API to conform to treating images as resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The architecture of the Koromoth Viewer backend is simple and serverless, consis
 
 The API Gateway provides a public HTTP endpoint that clients can use to request image URLs. It is configured with CORS (Cross-Origin Resource Sharing) to allow requests from any origin. The following endpoints are available:
 
-*   `GET /image?key=<FILENAME>`: Retrieves a pre-signed URL for a specific image.
+*   `GET /image/<KEY>`: Retrieves a pre-signed URL for a specific image.
 *   `GET /images`: Retrieves a list of all available image keys in the bucket.
 
 ### Lambda Function

--- a/koromoth_viewer_cdk_py/koromoth_viewer_cdk_py_stack.py
+++ b/koromoth_viewer_cdk_py/koromoth_viewer_cdk_py_stack.py
@@ -73,14 +73,15 @@ class KoromothViewerCdkPyStack(Stack):
         )
 
         image_resource = api.root.add_resource("image")
-        image_resource.add_method("GET", apigw.LambdaIntegration(serve_image_lambda))
+        image_key_resource = image_resource.add_resource("{key}")
+        image_key_resource.add_method("GET", apigw.LambdaIntegration(serve_image_lambda))
 
         images_resource = api.root.add_resource("images")
         images_resource.add_method("GET", apigw.LambdaIntegration(list_images_lambda))
 
         # Output the API Gateway URL for easy access
         CfnOutput(self, "GetImageEndpoint",
-            value=f"{api.url}image?key=<YOUR_IMAGE_FILENAME.EXT>",
+            value=f"{api.url}image/<YOUR_IMAGE_FILENAME.EXT>",
             description="The API Gateway endpoint URL to get presigned image URLs. Replace <YOUR_IMAGE_FILENAME.EXT> with your S3 image key.",
         )
         CfnOutput(self, "ListImagesEndpoint",

--- a/lambda/get-image.js
+++ b/lambda/get-image.js
@@ -9,7 +9,7 @@ export const handler = async (event) => {
     try {
         console.log("Received event:", JSON.stringify(event, null, 2));
 
-        const imageKey = event.queryStringParameters?.key;
+        const imageKey = event.pathParameters?.key;
 
         if (!imageKey) {
             return {
@@ -20,7 +20,7 @@ export const handler = async (event) => {
                     'Access-Control-Allow-Headers': 'Content-Type',
                     'Access-Control-Allow-Methods': 'GET'
                 },
-                body: JSON.stringify({ message: 'Missing image key in query parameters. Use ?key=filename.jpg' }),
+                body: JSON.stringify({ message: 'Missing image key in path. Use /image/filename.jpg' }),
             };
         }
 


### PR DESCRIPTION
Instead of `/image?key=<YOUR_IMAGE_FILENAME.EXT>` use `/image/<YOUR_IMAGE_FILENAME.EXT>`