### PR TITLE
Fix /images endpoint to return sorted results.

### DIFF
--- a/koromoth_viewer_cdk_py/koromoth_viewer_cdk_py_stack.py
+++ b/koromoth_viewer_cdk_py/koromoth_viewer_cdk_py_stack.py
@@ -165,6 +165,10 @@ class KoromothViewerCdkPyStack(Stack):
             "KoromothViewerApi",
             rest_api_name="Koromoth Viewer Backend API",
             description="Serves presigned URLs for images from S3",
+            default_cors_preflight_options=apigw.CorsOptions(
+                allow_origins=["http://localhost:5173"],
+                allow_methods=apigw.Cors.ALL_METHODS,
+            ),
         )
 
         # --- API Gateway Resources ---

--- a/koromoth_viewer_cdk_py/koromoth_viewer_cdk_py_stack.py
+++ b/koromoth_viewer_cdk_py/koromoth_viewer_cdk_py_stack.py
@@ -59,6 +59,17 @@ class KoromothViewerCdkPyStack(Stack):
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,
         )
+        image_tags_table.add_global_secondary_index(
+            index_name="AllImagesIndex",
+            partition_key=dynamodb.Attribute(
+                name="GSI1PK", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name="ImageKey", type=dynamodb.AttributeType.STRING
+            ),
+            projection_type=dynamodb.ProjectionType.INCLUDE,
+            non_key_attributes=["ThumbnailUrl"],
+        )
 
         tag_images_table = dynamodb.Table(
             self,

--- a/lambda/add-tags.ts
+++ b/lambda/add-tags.ts
@@ -34,8 +34,9 @@ export const handler = async (
     const updateImageTagsCommand = new UpdateCommand({
       TableName: IMAGE_TAGS_TABLE_NAME,
       Key: { ImageKey: imageKey },
-      UpdateExpression: 'ADD Tags :t',
+      UpdateExpression: 'SET GSI1PK = :gsi1pk ADD Tags :t',
       ExpressionAttributeValues: {
+        ':gsi1pk': 'ALL_IMAGES',
         ':t': new Set(tags),
       },
     });

--- a/lambda/get-images.ts
+++ b/lambda/get-images.ts
@@ -162,9 +162,16 @@ const listAllImages = async (
 
   const queryCommand = new QueryCommand({
     TableName: IMAGE_TAGS_TABLE_NAME,
+    IndexName: 'AllImagesIndex', // Target the GSI
+    KeyConditionExpression: 'GSI1PK = :gsi1pk',
+    ExpressionAttributeValues: {
+      ':gsi1pk': 'ALL_IMAGES',
+    },
     ProjectionExpression: 'ImageKey, ThumbnailUrl',
     Limit: pageSize,
-    ExclusiveStartKey: !startKey ? undefined : { ImageKey: startKey },
+    ExclusiveStartKey: startKey
+      ? { GSI1PK: 'ALL_IMAGES', ImageKey: startKey }
+      : undefined,
   });
 
   const { Items, LastEvaluatedKey } = await ddbDocClient.send(queryCommand);

--- a/lambda/thumbnailer.ts
+++ b/lambda/thumbnailer.ts
@@ -58,9 +58,10 @@ export const handler = async (event: S3Event): Promise<void> => {
       const updateCommand = new UpdateCommand({
         TableName: IMAGE_TAGS_TABLE_NAME,
         Key: { ImageKey: imageKey },
-        UpdateExpression: 'SET ThumbnailUrl = :url',
+        UpdateExpression: 'SET ThumbnailUrl = :url, GSI1PK = :gsi1pk',
         ExpressionAttributeValues: {
           ':url': thumbnailUrl,
+          ':gsi1pk': 'ALL_IMAGES',
         },
       });
       await ddbDocClient.send(updateCommand);


### PR DESCRIPTION
- Add a global secondary index to the Images table
- Add CORS policy to allow local & cloudfront UI to work with the backend